### PR TITLE
Add details of AUR package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ a tool to analyze file system usage written in Rust
  - ability to compare different directories
  - fast, written in Rust
 
+More details at [ownyourbits.com](https://ownyourbits.com/2018/03/25/analize-disk-usage-with-dutree).
+
 # Usage
 
 ```
@@ -38,6 +40,15 @@ Options:
 cargo install dutree
 ```
 
-There's also standalone binaries in the [Releases section](https://github.com/nachoparker/dutree/releases)
+There's also standalone binaries for Linux in the [Releases section](https://github.com/nachoparker/dutree/releases)
 
-More details at [ownyourbits.com](https://ownyourbits.com/2018/03/25/analize-disk-usage-with-dutree)
+## Arch Linux
+
+You can install [the AUR package](https://aur.archlinux.org/packages/dutree/)
+with an AUR helper like `yaourt`, or manually:
+
+```bash
+git clone https://aur.archlinux.org/dutree.git
+cd bat
+makepkg -si
+```


### PR DESCRIPTION
I created [an AUR package for `dutree`](https://aur.archlinux.org/packages/dutree/), which makes it easy for people using Arch Linux to install and manage it with the system package manager, `pacman`.

This PR adds a note to the README mentioning the AUR package.