### PR TITLE
Gracefully handle bad or invalid symlinks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,14 +481,16 @@ fn get_bytes( path: &Path, usage_flag : bool ) -> u64 {
 
 fn color_from_path<'a>( path : &Path, color_dict : &'a HashMap<String, String> ) -> Option<&'a str> {
     if try_is_symlink( path ) {
-        if path.read_link().unwrap().exists() {
-            if let Some( col ) = color_dict.get( &"ln".to_string() ) {
-                return Some( &col );
+        let path_link = path.read_link();
+        if path_link.is_ok() {
+            if path_link.unwrap().exists() {
+                if let Some(col) = color_dict.get(&"ln".to_string()) {
+                    return Some(&col);
+                }
             }
-        } else {
-            if let Some( col ) = color_dict.get( &"or".to_string() )  {
-                return Some( &col );
-            }
+        }
+        if let Some( col ) = color_dict.get( &"or".to_string() )  {
+            return Some( &col );
         }
     }
     let metadata = path.symlink_metadata();


### PR DESCRIPTION
`read_link` can return an error for symlinks that aren't valid. This is specifically reproducible if `dutree` evaluates a [weird symlink](https://unix.stackexchange.com/questions/197854/how-does-the-proc-pid-exe-symlink-differ-from-ordinary-symlinks) such as `/proc/2/task/2/exe`.

While guarding against listing things in `proc` might not specifically be useful, it seems reasonable (at least to me) that there would be actual broken/misbehaving links in the wild.