### PR TITLE
Update signal-hook dependency, add Guix installation instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 getopts = "0.2.21"
 regex = "1.3.9"
-signal-hook = "0.1.10"
+signal-hook = "0.3.10"
 terminal_size = "0.1.8"
 unicode-width = "0.1.1"
 unicode-segmentation = "1.2.0"

--- a/README.md
+++ b/README.md
@@ -60,3 +60,11 @@ You can install `dutree` from the official Fedora repositories:
 ```sh
 $ sudo dnf -y install dutree
 ```
+
+## Guix
+
+You can install `dutree` in Guix:
+
+```sh
+$ guix install dutree
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ use std::process;
 fn main() {
 
     // handle SIGPIPE
-    let _signal = unsafe { signal_hook::register(signal_hook::SIGPIPE, || process::exit(0)) };
+    let _signal = unsafe { signal_hook::low_level::register(signal_hook::consts::signal::SIGPIPE, || process::exit(0)) };
 
     // Parse arguments
     let cfg = match Config::new() {


### PR DESCRIPTION
I'd like to remove the old version of signal-hook from Guix, only keeping the latest version, hence the first patch. It runs succesfully.